### PR TITLE
Add support to configure requests pool options

### DIFF
--- a/ftui/ftui.py
+++ b/ftui/ftui.py
@@ -401,6 +401,14 @@ def setup(args):
 
     print(__doc__)
 
+    pool_connections = 20
+    if args.pool_connections:
+        pool_connections = args.pool_connections
+
+    pool_maxsize = 10
+    if args.pool_maxsize:
+        pool_maxsize = args.pool_maxsize
+
     if args.yaml:
         for s in args.servers:
             try:
@@ -411,6 +419,8 @@ def setup(args):
                     username=s["username"],
                     password=s["password"],
                     config_path=config,
+                    pool_connections=pool_connections,
+                    pool_maxsize=pool_maxsize,
                 )
 
                 client_dict[ftui_client.name] = ftui_client
@@ -419,7 +429,11 @@ def setup(args):
     else:
         if config is not None:
             try:
-                ftui_client = ftuic.FTUIClient(config_path=config)
+                ftui_client = ftuic.FTUIClient(
+                    config_path=config,
+                    pool_connections=pool_connections,
+                    pool_maxsize=pool_maxsize,
+                )
                 client_dict[ftui_client.name] = ftui_client
             except Exception as e:
                 raise RuntimeError("Cannot create freqtrade client") from e
@@ -439,6 +453,8 @@ def main():
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose debugging mode")
 
     parser.add_argument("-c", "--config", nargs="?", help="Config to parse")
+    parser.add_argument("--pool_connections", nargs="?", default=20, help="Number of pool connections")
+    parser.add_argument("--pool_maxsize", nargs="?", default=10, help="Pool cache maxsize")
 
     parser.add_argument(
         "-y", "--yaml", nargs="?", help="Supply a YAML file instead of command line arguments."

--- a/ftui/ftui_client.py
+++ b/ftui/ftui_client.py
@@ -28,6 +28,8 @@ class FTUIClient:
         password: Optional[str] = None,
         *,
         config_path=None,
+        pool_connections=20,
+        pool_maxsize=10,
     ):
         self.name = name
         self.url = url
@@ -37,6 +39,8 @@ class FTUIClient:
         self.config_path = config_path
         self.rest_client = None
         self.config = None
+        self.pool_connections = pool_connections
+        self.pool_maxsize = pool_maxsize
 
         self.prev_closed_trade_count = 0
         self.all_closed_trades = []
@@ -65,7 +69,11 @@ class FTUIClient:
 
         server_url = f"http://{self.url}:{self.port}"
 
-        client = ftrc.FtRestClient(server_url, self.username, self.password)
+        client = ftrc.FtRestClient(server_url,
+                                   self.username,
+                                   self.password,
+                                   pool_connections=self.pool_connections,
+                                   pool_maxsize=self.pool_maxsize)
 
         if client is not None:
             c = client.version()


### PR DESCRIPTION
This PR adds support to control the number and size of pooled connections for the requests HTTPAdapter. If you're using quite a lot of bots within FTUI, the pool can become saturated and warnings will appear in the terminal. Increasing the pool_connections and pool_maxsize properties can help with this.

These two options:
- can now be supplied in the FTUI config yaml or on the command line if using a freqtrade config file
- default to higher numbers than the requests library/ft rest client defaults (10 and 10, respectively are now 20 and 10)